### PR TITLE
Add blazed.sh to list of node providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ _If you really appreciate the content of this repository, don't forget to give i
 | [QuickNode](https://www.quicknode.com)| A single platform for your production, staging, and testing environments                      |
 | [Ankr](https://www.ankr.com/protocol/)| The fastest and most reliable Web3 infrastructure provider                                    |
 | [GetBlock](https://getblock.io/)| A flexible Blockchain RPC Provider that offers instant API access to over 50 multiple blockchains   |
+| [BLAZED.sh](https://blazed.sh)| BLAZED.sh allows hosting applications directly on servers that are also ETH Nodes                      |
 
 <div align="right">
     <b><a href="##table-of-contents">↥ Back To Top</a></b>


### PR DESCRIPTION
I added a new provider to the Node provider list.
blazed.sh is offering Docker and JS Script deployments that have access to Ethereum RPC via IPC sockets.